### PR TITLE
Reorganize note sections, fix Renovate contributions in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -52,12 +52,13 @@ autolabeler:
       - '/update/i'
 exclude-contributors:
   - 'figure-renovate'
+  - 'figure-renovate[bot]'
 replacers:
   - search: '/\[sc-(\d+)\]/gi'
     replace: '[[sc-$1](https://app.shortcut.com/figure/story/$1)]'
   - search: '/\[ch(\d+)\]/gi'
     replace: '[[sc-$1](https://app.shortcut.com/figure/story/$1)]'
-  - search: '/@figure-renovate$/gim'
+  - search: '/@figure-renovate(\[bot\])?$/gim'
     replace: 'by [Renovate](https://github.com/renovatebot/renovate)'
 template: |
   # Changelog

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,8 +48,15 @@ autolabeler:
     title:
       - '/docs/i'
   - label: 'dependencies'
+    branch:
+      - '/update\/.+/'
     title:
       - '/update/i'
+  - label: 'chore'
+    branch:
+      - '/chore\/.+/'
+    title:
+      - '/chore/i'
 exclude-contributors:
   - 'figure-renovate'
   - 'figure-renovate[bot]'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -50,18 +50,24 @@ autolabeler:
   - label: 'dependencies'
     title:
       - '/update/i'
+exclude-contributors:
+  - 'figure-renovate'
 replacers:
   - search: '/\[sc-(\d+)\]/gi'
     replace: '[[sc-$1](https://app.shortcut.com/figure/story/$1)]'
   - search: '/\[ch(\d+)\]/gi'
     replace: '[[sc-$1](https://app.shortcut.com/figure/story/$1)]'
+  - search: '/@figure-renovate$/gim'
+    replace: 'by [Renovate](https://github.com/renovatebot/renovate)'
 template: |
   # Changelog
   $CHANGES
   # Notes
+  ## Compatible Versions
+  - [Provenance vProvenanceVersionHere](https://github.com/provenance-io/provenance/blob/vProvenanceVersionHere/docs/Building.md)
+  ## Required Updates
+  The relevant PRs and all work that needs to be done for this release to succeed (like updating dependencies) should be listed here
   ## Contributors
   $CONTRIBUTORS
-  ## Required Updates
-  The relevant PRs and all work that needs to be done for this release to succeed should be listed here
   ## Other
   Other notes

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,8 @@ on:
   # For autolabeling PRs from forks
   pull_request_target:
     types: [ synchronize, opened, reopened, ready_for_review ]
+  # For manually running the autolabeler
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Context
The initial draft release that currently gets generated by Release Drafter could use some cleanup for its entries created by Renovate
## Changes
- Remove Renovate bot from contributors list of release notes
- Add replacer for Renovate contributions with working link to the bot's repository
- Add a Compatible Versions section to release drafts
- Move the Required Updates section of release drafts up
- Allow manual running of the autolabeler
- Add autolabeling of 'chore' by branch or PR name
- Add autolabeling of 'dependencies' by branch name