### PR TITLE
Group cosmwasm and provwasm Renovate updates together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,20 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>FigureTechnologies/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "groupName": "provwasm",
+      "matchPackagePrefixes": [
+        "provwasm"
+      ]
+    },
+    {
+      "groupName": "cosmos",
+      "matchPackagePrefixes": [
+        "cosmwasm",
+        "cw-"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Context
The dependency update in [#8 has an error](https://github.com/FigureTechnologies/validation-oracle-smart-contract/pull/8#issuecomment-1368430228) because it needed to be grouped by Renovate with the update in #9.
## Changes
- Attempt to group dependency updates together for cosmwasm packages and provwasm packages