### PR TITLE
Group provwasm & cosmwasm updates together rather than individually

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,14 +5,9 @@
   ],
   "packageRules": [
     {
-      "groupName": "provwasm",
+      "groupName": "provwasm & cosmwasm",
       "matchPackagePrefixes": [
-        "provwasm"
-      ]
-    },
-    {
-      "groupName": "cosmos",
-      "matchPackagePrefixes": [
+        "provwasm",
         "cosmwasm",
         "cw-"
       ]


### PR DESCRIPTION
## Context
#10 was incorrect in that provwasm updates need to _also_ be grouped with cosmwasm updates (obviously)
## Changes
- Combine Renovate package groups for cosmwasm and provwasm packages into singular group