### PR TITLE
Allow Codecov upload to fail in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
         with:
           files: cobertura.xml
           flags: unittests
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
 
   # TODO: Add job for publishing Rustdocs to GitHub


### PR DESCRIPTION
## Context
Codecov continues to log the following error in the CI workflow
```
['verbose'] The error stack is: Error: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Could not find a repository, try using repo upload token', code='not_found')}
    at main (/snapshot/repo/dist/src/index.js)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```
I had allowed the step to cause a failure if the upload failed in hopes that it would eventually resolve itself, but that hasn't been the case and it's simply inconvenient to continue letting builds have a failing status for a problem out of our control
## Changes
- Disable Codecov upload failures from propagating to the workflow