### PR TITLE
Correct cosmwasm version upgrade, update miscellaneous version strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CONTAINER_RUNTIME := $(shell which docker 2>/dev/null || which podman 2>/dev/nul
 ### Use cosmwasm/rust-optimizer-arm64 on M1 Macs (https://hub.docker.com/r/cosmwasm/rust-optimizer-arm64)
 OPTIMIZER_IMAGE := cosmwasm/rust-optimizer
 ### 0.12.10 is the latest tag (https://hub.docker.com/r/cosmwasm/rust-optimizer/tags)
-OPTIMIZER_DOCKER_TAG := 0.12.10
+OPTIMIZER_DOCKER_TAG := 0.12.11
 
 .PHONY: all
 all: clean build fmt lint test schema docs optimize

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ _TODO: Add details on the data model, the assumptions it makes, and how the cont
 
 This project has been tested and confirmed to work with
 
-- [Rust](https://www.rust-lang.org/tools/install) 1.66.0
-- [Provenance](https://github.com/provenance-io/provenance/blob/main/docs/Building.md) 1.13.0
+- [Rust](https://www.rust-lang.org/tools/install) 1.66.1
+- [Provenance](https://github.com/provenance-io/provenance/blob/main/docs/Building.md) 1.13.1
   - [Go](https://go.dev/dl/) 1.19.3
 
 ### Running a Local Demo

--- a/examples/schema.rs
+++ b/examples/schema.rs
@@ -1,19 +1,14 @@
-use std::env::current_dir;
-use std::fs::create_dir_all;
-
-use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
-
 use validation_oracle_smart_contract::types::core::msg::{
     ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
 };
 
+use cosmwasm_schema::write_api;
+
 fn main() {
-    let mut out_dir = current_dir().unwrap();
-    out_dir.push("schema");
-    create_dir_all(&out_dir).unwrap();
-    remove_schemas(&out_dir).unwrap();
-    export_schema(&schema_for!(ExecuteMsg), &out_dir);
-    export_schema(&schema_for!(InstantiateMsg), &out_dir);
-    export_schema(&schema_for!(QueryMsg), &out_dir);
-    export_schema(&schema_for!(MigrateMsg), &out_dir);
+    write_api! {
+        instantiate: InstantiateMsg,
+        query: QueryMsg,
+        execute: ExecuteMsg,
+        migrate: MigrateMsg,
+    }
 }

--- a/src/storage/validation_definition.rs
+++ b/src/storage/validation_definition.rs
@@ -185,6 +185,7 @@ pub fn delete_validation_definition_by_key<S: Into<String>>(
         .to_err()
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::{get_validation_definition, insert_validation_definition};

--- a/src/types/core/msg.rs
+++ b/src/types/core/msg.rs
@@ -1,18 +1,24 @@
-use crate::types::{
-    entity::EntityDetail,
-    request::{
-        settings_update::SettingsUpdate,
-        validation_definition::{
-            ValidationDefinitionCreationRequest, ValidationDefinitionUpdateRequest,
+use crate::{
+    storage::contract_info::ContractInfo,
+    types::{
+        entity::EntityDetail,
+        request::{
+            settings_update::SettingsUpdate,
+            validation_definition::{
+                ValidationDefinitionCreationRequest, ValidationDefinitionUpdateRequest,
+            },
+            validation_request::{
+                ValidationRequest, ValidationRequestOrder, ValidationRequestUpdate,
+            },
+            validator_configuration::{
+                ValidatorConfigurationCreationRequest, ValidatorConfigurationUpdateRequest,
+            },
         },
-        validation_request::{ValidationRequest, ValidationRequestUpdate},
-        validator_configuration::{
-            ValidatorConfigurationCreationRequest, ValidatorConfigurationUpdateRequest,
-        },
+        validation_definition::ValidationDefinition,
     },
-};
+}; // TODO: These unused import warnings may be a Rust bug
 
-use cosmwasm_schema::cw_serde;
+use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Uint128};
 
 #[cw_serde]
@@ -66,14 +72,21 @@ pub enum ExecuteMsg {
 }
 
 #[cw_serde]
+#[derive(QueryResponses)]
 pub enum QueryMsg {
+    #[returns(Option<EntityDetail>)]
     QueryEntityByAddress { address: Addr },
+    #[returns(Option<ValidationDefinition>)]
     QueryValidationDefinitionByType { r#type: String },
+    #[returns(Option<ValidationRequestOrder>)]
     QueryValidationRequestById { id: String },
+    #[returns(Vec<ValidationRequestOrder>)]
     QueryValidationRequestByOwner { owner: Addr },
+    #[returns(Vec<ValidationRequestOrder>)]
     QueryValidationRequestByValidator { validator: Addr },
     //QueryValidationResultsBy...
     //QueryValidatorConfigurationBy...
+    #[returns(ContractInfo)]
     QueryContractInfo {},
 }
 


### PR DESCRIPTION
## Context
Updates to the cosmwasm version in earlier commits were incomplete/incorrect in either:
- updating the cosmwasm version when provwasm had not been updated to the same version accordingly — fixed by #12
- not completely performing the necessary code updates for new cosmwasm releases per [their migration guide](https://github.com/CosmWasm/cosmwasm/blob/main/MIGRATING.md) — fixed in this PR
## Changes
- Update Rust optimizer image version
- Update patch versions of Rust & Provenance in README
- Add missed changes from Cosmwasm migration guide