### PR TITLE
Add workflow for uploading WASM & JSON schema to GitHub releases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,13 @@
 # top-most EditorConfig file
 root = true
 
+[Makefile]
+indent_style = tab
+
+[.github/workflows/**.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
 [*]
 indent_style = space
 indent_size = 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,11 @@ on:
       linting:
         type: boolean
         description: Run the linter
+        default: false
       runCodeCoverage:
         type: boolean
         description: Run code coverage
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
     types: [ synchronize, opened, reopened, ready_for_review, converted_to_draft ]
   workflow_dispatch:
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   linting:
     name: Linting
@@ -29,26 +32,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
+      - name: Install stable Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           default: true
-          components: clippy, rustfmt
-
-      - name: Cargo — Format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+          components: clippy
 
       - name: Cargo — Clippy
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: "-D warnings"
         with:
           command: clippy
 
-      - name: Cargo — Documentation # TODO: Move to new job that publishes the docs to GitHub Pages
+      - name: Cargo — Check documentation
         uses: actions-rs/cargo@v1
+        env:
+          RUSTDOCFLAGS: "-D warnings"
         with:
           command: doc
 
@@ -56,7 +57,6 @@ jobs:
     name: Check Project Integrity
     runs-on: ubuntu-latest
     env:
-      CARGO_TERM_COLOR: always
       RUN_CODE_COVERAGE:
         ${{
           github.event.inputs.runCodeCoverage ||
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
+      - name: Install stable Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -89,7 +89,7 @@ jobs:
         if: always()
         with:
           check_name: "Test Results"
-          pull_request_build: "commit"
+          pull_request_build: ${{ github.event_name == 'push' && 'commit' || 'merge' }}
           report_individual_runs: true
           files: "test-results.xml"
 
@@ -109,5 +109,3 @@ jobs:
           flags: unittests
           fail_ci_if_error: true
           verbose: true
-
-  # TODO: Add job for publishing Rustdocs to GitHub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
   linting:
     name: Linting
     runs-on: ubuntu-latest
-    if: github.event.inputs.linting || !github.event.pull_request.draft
+    if: github.event.inputs.linting || (github.event_name == 'pull_request' && !github.event.pull_request.draft)
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,9 @@ on:
       linting:
         type: boolean
         description: Run the linter
-        default: true
       runCodeCoverage:
         type: boolean
         description: Run code coverage
-        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,7 +25,7 @@ jobs:
   linting:
     name: Linting
     runs-on: ubuntu-latest
-    if: github.event.inputs.linting || (github.event_name == 'pull_request' && !github.event.pull_request.draft)
+    if: github.event.inputs.linting || github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.draft)
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,100 @@
+name: Upload Documentation
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+    inputs:
+      targetTag:
+        type: string
+        description: The tag of the GitHub release to update
+        required: true
+      publishFiles:
+        type: boolean
+        description: Upload WASM & JSON schema to GitHub release
+        default: true
+      updateDocsSite:
+        type: boolean
+        description: Upload documentation to GitHub Pages
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish-files:
+    name: Publish Contract WASM & JSON schema
+    runs-on: ubuntu-latest
+    if: github.event.inputs.publishFiles || github.event_name == 'release'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Generate JSON schema
+        run: make schema
+
+      - name: Build & optimize WASM
+        run: make optimize
+
+      - name: Get release information
+        id: release_info
+        uses: cardinalby/git-get-release-action@1.2.4
+        if: github.event_name != 'release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ github.event.inputs.targetTag }}
+
+      - name: Upload files to GitHub release
+        uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_id: ${{ github.event_name == 'release' && github.event.release.id || steps.release_info.outputs.id }}
+          file: |
+            artifacts/asset_classification_smart_contract.wasm
+            artifacts/checksums.txt
+            schema/validation_oracle_smart_contract.json
+          overwrite: true
+
+  upload-docs:
+    name: Upload Documentation to GitHub Pages
+    runs-on: ubuntu-latest
+    if: github.event.inputs.updateDocsSite || (github.event_name == 'release' && !github.event.release.prerelease)
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            default: true
+
+      - name: Cargo — Generate & check documentation
+        uses: actions-rs/cargo@v1
+        env:
+            RUSTDOCFLAGS: '-D warnings'
+        with:
+            command: doc
+
+      - name: Stage documentation
+        if: env.UPLOAD_TO_GITHUB_PAGES
+        run: |
+          # Add redirect page to inner doc index
+          echo "<meta http-equiv=\"refresh\" content=\"0; url=docs\">" >> ./target/doc/index.html
+          # Create doc deployment location
+          mkdir ./pages-files
+          # Move documentation to its configured location in settings
+          cp -r target/doc ./pages-files/docs
+
+      - name: Deploy documentation to GitHub Pages
+        if: env.UPLOAD_TO_GITHUB_PAGES
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          branch: github-pages-for-docs
+          folder: pages-files

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ CONTAINER_RUNTIME := $(shell which docker 2>/dev/null || which podman 2>/dev/nul
 
 ### Use cosmwasm/rust-optimizer-arm64 on M1 Macs (https://hub.docker.com/r/cosmwasm/rust-optimizer-arm64)
 OPTIMIZER_IMAGE := cosmwasm/rust-optimizer
-### 0.12.10 is the latest tag (https://hub.docker.com/r/cosmwasm/rust-optimizer/tags)
-OPTIMIZER_DOCKER_TAG := 0.12.10
+### See tags here: https://hub.docker.com/r/cosmwasm/rust-optimizer/tags
+OPTIMIZER_DOCKER_TAG ?= 0.12.11
 
 .PHONY: all
 all: clean build fmt lint test schema docs optimize


### PR DESCRIPTION
## Context
It would be useful to have the JSON schema of the contract's entry points & the optimized WASM of the contract published alongside their respective GitHub releases. It would also be useful to upload the Cargo-generated documentation for the source code to a site for anyone to browse without having to build it locally.
## Changes
- Add workflow, triggered on release publication or manually, that uploads
  - the JSON schema of the contract's entry points to the release
  - the optimized WASM of the contract to the release
  - the Cargo-generated documentation to GitHub Pages
- Clean up build workflow
- Add sections for Makefile and GitHub workflows to `.editorconfig`